### PR TITLE
Fix navbar tabbing order

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,32 +29,32 @@
                         <span class="icon-bar"></span>
                     </button>
                     <a class="navbar-brand" routerlink="games" ng-reflect-router-link="games" href="/games">
-                        <img src="favicon.png"> OverTrack
+                        <img src="favicon.png" alt="OverTrack Logo"> OverTrack
                     </a>
                 </div>
                 <div class="navbar-collapse collapse" id="navbar">
                     <ul class="nav navbar-nav" routerlinkactive="active" ng-reflect-router-link-active="active">
-                        <li class="nav-item" tabindex="0" ng-reflect-router-link="games">
+                        <li class="nav-item" ng-reflect-router-link="games">
                             <a class="nav-link" href="/games">Games</a>
                         </li>
-                        <li class="nav-item" tabindex="0" ng-reflect-router-link="graph">
+                        <li class="nav-item" ng-reflect-router-link="graph">
                             <a class="nav-link" href="/graph">SR Graph</a>
                         </li>
-                        <li class="nav-item" tabindex="0" ng-reflect-router-link="statistics">
+                        <li class="nav-item" ng-reflect-router-link="statistics">
                             <a class="nav-link" href="/statistics">Statistics</a>
                         </li>
-                        <li class="nav-item" tabindex="0" ng-reflect-router-link="winrates">
+                        <li class="nav-item" ng-reflect-router-link="winrates">
                             <a class="nav-link" href="/winrates">Win Rates</a>
                         </li>
                         <li class="divider-vertical"></li>
                         
-                        <li class="nav-item" routerlink="tracker" tabindex="0" ng-reflect-router-link="tracker">
+                        <li class="nav-item" routerlink="tracker" ng-reflect-router-link="tracker">
                             <a class="nav-link" href="/tracker">Download Tracker</a>
                         </li>
-                        <li class="nav-item" routerlink="faq" tabindex="0" ng-reflect-router-link="faq">
+                        <li class="nav-item" routerlink="faq" ng-reflect-router-link="faq">
                             <a class="nav-link" href="/faq">FAQ / Troubleshooting</a>
                         </li>
-                        <li class="nav-item" routerlink="subscribe" tabindex="0" ng-reflect-router-link="subscribe">
+                        <li class="nav-item" routerlink="subscribe" ng-reflect-router-link="subscribe">
                             <a class="nav-link" href="/subscribe">Subscription</a>
                         </li>
                     </ul>


### PR DESCRIPTION
For #19, I fixed the first navbar tabbing issue. I also added an alt-text for the logo image. **li** tag doesn't need **tabindex** since **a** tag has a tab order by default.

Unfortunately, for the second issue, I cannot work on it for the moment. I mainly work on Mac and my Windows laptop is too old to run the games.

